### PR TITLE
Fix environs read_env crash in Nuitka-frozen desktop binary

### DIFF
--- a/app/src/folioman_app/_env.py
+++ b/app/src/folioman_app/_env.py
@@ -16,4 +16,8 @@ from environs import Env
 
 env = Env()
 # Load a .env from the CWD/ancestors if present (local dev); silent when absent.
-env.read_env()
+# Pass an explicit relative name: environs' no-arg read_env() derives the caller's
+# directory from the module's __file__ and walks up from there, but under a Nuitka
+# frozen build that __file__ isn't a real filesystem path and dotenv._walk_to_root
+# raises "OSError: Starting path not found". Starting from the real CWD fixes it.
+env.read_env(".env")


### PR DESCRIPTION
`env.read_env()` with no argument makes environs 15.x derive the search-start
directory from the calling module's `__file__`. Under Nuitka's frozen build that
`__file__` doesn't exist on disk, so `dotenv._walk_to_root()` raises
`OSError: Starting path not found` and the desktop app dies inside
`django.setup()` at launch.

Passing an explicit relative `".env"` makes the search start from the real CWD —
still a silent no-op when no `.env` exists, so dev/server behavior is unchanged.

Verification:
- `make desktop` builds successfully.
- The frozen binary now completes bootstrap (`desktop bootstrap complete` logged)
  where it previously crashed with the OSError.
- `make lint` passes.