### PR TITLE
fix : issue with starting application using docker instance in windows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,13 +26,15 @@ htmlcov/
 *.log
 .DS_Store
 
-# Local data + secrets (never bake into an image)
+# Local data + secrets (never bake into an image). Patterns without a leading
+# **/ only match the build-context root, NOT nested dirs (e.g. frontend/.env) —
+# the **/ prefix is required or a dev-only VITE_API_BASE etc. leaks into the image.
 **/*.sqlite3
 **/*.sqlite3-shm
 **/*.sqlite3-wal
-.env
-.env.*
-!.env.example
+**/.env
+**/.env.*
+!**/.env.example
 secrets/
 
 # Editor / OS

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must keep LF endings — CRLF breaks the shebang inside Linux
+# containers (exec: no such file or directory). See server/docker-entrypoint.sh.
+*.sh text eol=lf
+docker-entrypoint.sh text eol=lf


### PR DESCRIPTION
.gitattributes is necessary because in windows files are converted into CRLF as a result docker is not coming up